### PR TITLE
Remove needless `.async = true`

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,6 @@
 
 	function injectScript(src, cb) {
 		const script = document.createElement('script');
-		script.async = true;
 		script.src = src;
 		script.addEventListener('load', cb);
 		document.head.appendChild(script);


### PR DESCRIPTION
Dynamically inserted <script>s default to `.async=true`.

Explicitly setting `.async = true` for dynamically inserted scripts is only worthwhile in Firefox 3.6 and OmniWeb 622, and even then only under certain circumstances. See https://mathiasbynens.be/notes/async-analytics-snippet#async for details.