### PR TITLE
Update subject/body script for Firefox

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -28,7 +28,7 @@ if (originalSearchParams.has('body')) {
 	searchParams.set('body', originalSearchParams.get('body'));
 }
 
-element.search = searchParams.toString();
+element.href = `${element.href}?${searchParams.toString()}`;
 </script>
 
 # Contact


### PR DESCRIPTION
```js
element.search = searchParams.toString();
```
doesn't work in the latest firefox 
![Screenshot 2020-07-26 at 9 17 51 AM](https://user-images.githubusercontent.com/44947946/88471289-5108da00-cef7-11ea-9496-1df7843dc573.png)


Using 
```js
element.href = `${element.href}?${searchParams.toString()}`;
```
works instead