### PR TITLE
Fix issue where gradient text cropped when using .tracking-tighter

### DIFF
--- a/source/components/widgets/Hero.astro
+++ b/source/components/widgets/Hero.astro
@@ -24,10 +24,8 @@ import {Icon} from 'astro-icon';
 		<div class="m-auto py-12 md:py-20">
 			<div class="text-center pb-10 md:pb-16">
 				<img src="/assets/sindre-sorhus.jpg" class="mx-auto m-8 rounded-full" width="144" height="144">
-				<h1 class="text-5xl md:text-[3.50rem] font-bold leading-tighter tracking-tighter mb-4 font-heading">
-					<span class="background-animate bg-clip-text text-transparent bg-gradient-to-r from-primary-500 to-secondary-500 sm:whitespace-nowrap">
-						Sindre Sorhus
-					</span>
+				<h1 class="text-5xl md:text-[3.50rem] font-bold leading-tighter tracking-tighter mb-4 font-heading background-animate bg-clip-text text-transparent bg-gradient-to-r from-primary-500 to-secondary-500 sm:whitespace-nowrap">
+					Sindre Sorhus
 				</h1>
 				<div class="max-w-3xl mx-auto">
 					<p class="text-xl text-gray-600 mb-8 dark:text-slate-400">

--- a/source/pages/apps.astro
+++ b/source/pages/apps.astro
@@ -23,7 +23,7 @@ const tagClass = 'text-[10px] inline-flex items-center font-bold leading-sm px-1
 				<!-- TODO: Make title components -->
 				<h1 class="text-center text-4xl md:text-6xl font-bold leading-tighter tracking-tighter mb-8 md:mb-16 font-heading">
 					Quality crafted
-					<span class="bg-clip-text text-transparent bg-gradient-to-r from-primary-500 to-secondary-500">apps</span>
+					<span class="bg-clip-text text-transparent bg-gradient-to-r from-primary-500 to-secondary-500 pr-[0.025em] mr-[-0.025em]">apps</span>
 				</h1>
 				<!-- TODO: Put the below in a popover -->
 				<!-- <p>If you're a student, open-source maintainer, or cannot afford my paid apps, <a href="/contact?subject=Free%20promo%20code%20for%20%5Bapp%5D">reach out</a>, and I'll give you any of my apps for free.</p>


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/sindresorhus.github.com/issues/19

For the home page, I consolidated the classes being used and removed the span.

For the apps page, I used [arbitrary values](https://tailwindcss.com/docs/padding#arbitrary-values) to add `padding-right` and negative `margin-right`.

This might be related to a known issue with `letter-spacing`. I referenced a [video from Kevin Powell](https://www.youtube.com/watch?v=dNLMjz_CfJU) when working on this PR.

I would not be surprised if there is a more elegant way of handling this, but this was my approach. Here are the results:

![home-fixed](https://user-images.githubusercontent.com/25012869/201500019-e3089132-1e35-42fb-8e3a-c225b1ebf85f.png)

![apps-fixed](https://user-images.githubusercontent.com/25012869/201500022-185f3444-9e1d-4811-a597-fcb10bfada24.png)



